### PR TITLE
Registration flow improvements and IAP

### DIFF
--- a/Vaccinations2_0/ContentView.swift
+++ b/Vaccinations2_0/ContentView.swift
@@ -7,17 +7,21 @@ import SwiftUI
 
 struct ContentView: View {
     @EnvironmentObject var viewModel: VaccineViewModel
+    @EnvironmentObject var subscriptionManager: SubscriptionManager
     
     var body: some View {
         Group {
             if viewModel.isFirstLaunch {
                 OnboardingView()
+            } else if viewModel.childProfile != nil && !subscriptionManager.hasPremiumAccess {
+                PaywallView()
             } else {
                 VaccineListView()
             }
         }
         .onAppear {
             viewModel.loadData()
+            Task { await subscriptionManager.refreshEntitlements() }
         }
     }
 }

--- a/Vaccinations2_0/Models/ChildProfile.swift
+++ b/Vaccinations2_0/Models/ChildProfile.swift
@@ -62,6 +62,7 @@ struct ChildProfile: Codable {
 
 // List of supported countries
 enum Country: String, CaseIterable {
+    case usa = "USA"
     case argentina = "Argentina"
     case brazil = "Brazil"
     case china = "China"
@@ -76,10 +77,10 @@ enum Country: String, CaseIterable {
     case philippines = "Philippines"
     case russia = "Russia"
     case turkey = "Turkey"
-    case usa = "USA"
     
     var flag: String {
         switch self {
+        case .usa: return "🇺🇸"
         case .argentina: return "🇦🇷"
         case .brazil: return "🇧🇷"
         case .china: return "🇨🇳"
@@ -94,12 +95,12 @@ enum Country: String, CaseIterable {
         case .philippines: return "🇵🇭"
         case .russia: return "🇷🇺"
         case .turkey: return "🇹🇷"
-        case .usa: return "🇺🇸"
         }
     }
     
     var displayName: String {
         switch self {
+        case .usa: return "\(flag) United States"
         case .argentina: return "\(flag) Argentina"
         case .brazil: return "\(flag) Brazil"
         case .china: return "\(flag) China"
@@ -114,12 +115,12 @@ enum Country: String, CaseIterable {
         case .philippines: return "\(flag) Philippines"
         case .russia: return "\(flag) Russia"
         case .turkey: return "\(flag) Turkey"
-        case .usa: return "\(flag) United States"
         }
     }
     
     var localizedName: String {
         switch self {
+        case .usa: return NSLocalizedString("United States", comment: "")
         case .argentina: return NSLocalizedString("Argentina", comment: "")
         case .brazil: return NSLocalizedString("Brazil", comment: "")
         case .china: return NSLocalizedString("China", comment: "")
@@ -134,7 +135,6 @@ enum Country: String, CaseIterable {
         case .philippines: return NSLocalizedString("Philippines", comment: "")
         case .russia: return NSLocalizedString("Russia", comment: "")
         case .turkey: return NSLocalizedString("Turkey", comment: "")
-        case .usa: return NSLocalizedString("United States", comment: "")
         }
     }
     

--- a/Vaccinations2_0/Services/SubscriptionManager.swift
+++ b/Vaccinations2_0/Services/SubscriptionManager.swift
@@ -1,0 +1,168 @@
+//
+//  SubscriptionManager.swift
+//  VaccineCalendar
+//
+
+import Foundation
+import StoreKit
+
+@MainActor
+final class SubscriptionManager: ObservableObject {
+    // MARK: - Public state
+
+    @Published private(set) var products: [Product] = []
+    @Published private(set) var hasPremiumAccess: Bool
+    @Published private(set) var isLoading: Bool = false
+    @Published private(set) var lastErrorMessage: String?
+
+    // MARK: - Constants
+
+    /// Product IDs must match App Store Connect.
+    /// Configure **1 week free trial** as an introductory offer for the yearly subscription in App Store Connect.
+    enum ProductID {
+        static let monthly = "com.vaccinecalendar.subscription.monthly"
+        static let yearly = "com.vaccinecalendar.subscription.yearly"
+        static let all: [String] = [monthly, yearly]
+    }
+
+    private enum StorageKeys {
+        static let hasPremiumAccess = "hasPremiumAccess"
+        static let promoUnlocked = "promoUnlocked"
+        static let promoCodeUsed = "promoCodeUsed"
+    }
+
+    private let promoCodeFree = "khorokho"
+    private var updatesTask: Task<Void, Never>?
+
+    // MARK: - Init / deinit
+
+    init() {
+        let storedHasPremium = UserDefaults.standard.bool(forKey: StorageKeys.hasPremiumAccess)
+        let promoUnlocked = UserDefaults.standard.bool(forKey: StorageKeys.promoUnlocked)
+        self.hasPremiumAccess = storedHasPremium || promoUnlocked
+
+        updatesTask = Task { [weak self] in
+            await self?.listenForTransactionUpdates()
+        }
+
+        Task { [weak self] in
+            await self?.configure()
+        }
+    }
+
+    deinit {
+        updatesTask?.cancel()
+    }
+
+    // MARK: - Public API
+
+    func configure() async {
+        await loadProducts()
+        await refreshEntitlements()
+    }
+
+    func loadProducts() async {
+        isLoading = true
+        lastErrorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            let storeProducts = try await Product.products(for: ProductID.all)
+            products = storeProducts.sorted(by: { $0.displayName < $1.displayName })
+        } catch {
+            lastErrorMessage = error.localizedDescription
+            products = []
+        }
+    }
+
+    func purchase(product: Product) async {
+        isLoading = true
+        lastErrorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            let result = try await product.purchase()
+            switch result {
+            case .success(let verification):
+                let transaction = try requireVerified(verification)
+                await transaction.finish()
+                await refreshEntitlements()
+            case .userCancelled, .pending:
+                break
+            @unknown default:
+                break
+            }
+        } catch {
+            lastErrorMessage = error.localizedDescription
+        }
+    }
+
+    func restorePurchases() async {
+        isLoading = true
+        lastErrorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            try await AppStore.sync()
+            await refreshEntitlements()
+        } catch {
+            lastErrorMessage = error.localizedDescription
+        }
+    }
+
+    /// In-app promo code (not App Store promo codes). `khorokho` unlocks the app for free.
+    func applyPromoCode(_ code: String) {
+        let normalized = code.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !normalized.isEmpty else { return }
+
+        if normalized == promoCodeFree {
+            UserDefaults.standard.set(true, forKey: StorageKeys.promoUnlocked)
+            UserDefaults.standard.set(normalized, forKey: StorageKeys.promoCodeUsed)
+            setPremiumAccess(true)
+        } else {
+            lastErrorMessage = NSLocalizedString("Invalid promo code", comment: "")
+        }
+    }
+
+    // MARK: - Internals
+
+    func refreshEntitlements() async {
+        if UserDefaults.standard.bool(forKey: StorageKeys.promoUnlocked) {
+            setPremiumAccess(true)
+            return
+        }
+
+        var isActive = false
+        for await result in Transaction.currentEntitlements {
+            guard let transaction = try? requireVerified(result) else { continue }
+            if ProductID.all.contains(transaction.productID) {
+                isActive = true
+                break
+            }
+        }
+        setPremiumAccess(isActive)
+    }
+
+    private func listenForTransactionUpdates() async {
+        for await update in Transaction.updates {
+            guard let transaction = try? requireVerified(update) else { continue }
+            await transaction.finish()
+            await refreshEntitlements()
+        }
+    }
+
+    private func setPremiumAccess(_ newValue: Bool) {
+        hasPremiumAccess = newValue
+        UserDefaults.standard.set(newValue, forKey: StorageKeys.hasPremiumAccess)
+    }
+
+    private func requireVerified<T>(_ result: VerificationResult<T>) throws -> T {
+        switch result {
+        case .verified(let safe):
+            return safe
+        case .unverified(_, let error):
+            throw error
+        }
+    }
+}
+

--- a/Vaccinations2_0/VaccineCalendarApp.swift
+++ b/Vaccinations2_0/VaccineCalendarApp.swift
@@ -8,11 +8,13 @@ import SwiftUI
 @main
 struct VaccineCalendarApp: App {
     @StateObject private var viewModel = VaccineViewModel()
+    @StateObject private var subscriptionManager = SubscriptionManager()
     
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environmentObject(viewModel)
+                .environmentObject(subscriptionManager)
         }
     }
 }

--- a/Vaccinations2_0/Views/OnboardingView.swift
+++ b/Vaccinations2_0/Views/OnboardingView.swift
@@ -12,99 +12,109 @@ struct OnboardingView: View {
     @State private var selectedCountry: Country = .usa
     @State private var showDatePicker = false
     @State private var showCountrySelection = false
+    @FocusState private var isNameFocused: Bool
     
     var body: some View {
         NavigationView {
-            VStack(spacing: 30) {
-                // Header
-                VStack(spacing: 10) {
-                    Image(systemName: "heart.text.square.fill")
-                        .font(.system(size: 80))
-                        .foregroundColor(.blue)
-                    
-                    Text("Vaccination Calendar")
-                        .font(.largeTitle)
-                        .fontWeight(.bold)
-                    
-                    Text("Welcome!")
-                        .font(.title2)
-                        .foregroundColor(.secondary)
-                }
-                .padding(.top, 40)
-                
-                // Input Form
-                VStack(spacing: 20) {
-                    // Child's Name
-                    VStack(alignment: .leading, spacing: 8) {
-                        Label("Child's Name", systemImage: "person.fill")
-                            .font(.headline)
-                            .foregroundColor(.primary)
+            ScrollView {
+                VStack(spacing: 30) {
+                    // Header
+                    VStack(spacing: 10) {
+                        Image(systemName: "heart.text.square.fill")
+                            .font(.system(size: 80))
+                            .foregroundColor(.blue)
                         
-                        TextField("Enter name", text: $childName)
-                            .textFieldStyle(RoundedBorderTextFieldStyle())
-                            .autocapitalization(.words)
+                        Text("Vaccination Calendar")
+                            .font(.largeTitle)
+                            .fontWeight(.bold)
+                        
+                        Text("Welcome!")
+                            .font(.title2)
+                            .foregroundColor(.secondary)
                     }
+                    .padding(.top, 40)
                     
-                    // Birth Date
-                    VStack(alignment: .leading, spacing: 8) {
-                        Label("Date of Birth", systemImage: "calendar")
-                            .font(.headline)
-                            .foregroundColor(.primary)
+                    // Input Form
+                    VStack(spacing: 20) {
+                        // Child's Name
+                        VStack(alignment: .leading, spacing: 8) {
+                            Label("Child's Name", systemImage: "person.fill")
+                                .font(.headline)
+                                .foregroundColor(.primary)
+                            
+                            TextField("Enter name", text: $childName)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                                .autocapitalization(.words)
+                                .focused($isNameFocused)
+                        }
                         
-                        Button(action: {
-                            showDatePicker.toggle()
-                        }) {
-                            HStack {
-                                Text(dateFormatter.string(from: birthDate))
-                                    .foregroundColor(.primary)
-                                Spacer()
-                                Image(systemName: "chevron.down")
-                                    .foregroundColor(.secondary)
-                                    .font(.caption)
+                        // Birth Date
+                        VStack(alignment: .leading, spacing: 8) {
+                            Label("Date of Birth", systemImage: "calendar")
+                                .font(.headline)
+                                .foregroundColor(.primary)
+                            
+                            Button(action: {
+                                isNameFocused = false
+                                withAnimation(.easeInOut) {
+                                    showDatePicker.toggle()
+                                }
+                            }) {
+                                HStack {
+                                    Text(dateFormatter.string(from: birthDate))
+                                        .foregroundColor(.primary)
+                                    Spacer()
+                                    Image(systemName: showDatePicker ? "chevron.up" : "chevron.down")
+                                        .foregroundColor(.secondary)
+                                        .font(.caption)
+                                }
+                                .padding()
+                                .background(Color(.systemGray6))
+                                .cornerRadius(8)
                             }
-                            .padding()
-                            .background(Color(.systemGray6))
-                            .cornerRadius(8)
-                        }
-                        
-                        if showDatePicker {
-                            DatePicker("", selection: $birthDate, in: ...Date(), displayedComponents: .date)
-                                .datePickerStyle(GraphicalDatePickerStyle())
-                                .padding(.horizontal)
-                                .transition(.opacity)
-                        }
-                    }
-                    
-                    // Country Selection
-                    VStack(alignment: .leading, spacing: 8) {
-                        Label("Country", systemImage: "globe")
-                            .font(.headline)
-                            .foregroundColor(.primary)
-                        
-                        Button(action: {
-                            showCountrySelection = true
-                        }) {
-                            HStack {
-                                Text(selectedCountry.flag)
-                                    .font(.title2)
-                                Text(selectedCountry.localizedName)
-                                    .foregroundColor(.primary)
-                                Spacer()
-                                Image(systemName: "chevron.right")
-                                    .foregroundColor(.secondary)
-                                    .font(.caption)
+                            
+                            if showDatePicker {
+                                DatePicker("", selection: $birthDate, in: ...Date(), displayedComponents: .date)
+                                    .datePickerStyle(GraphicalDatePickerStyle())
+                                    .padding(.horizontal)
+                                    .transition(.opacity)
                             }
-                            .padding()
-                            .background(Color(.systemGray6))
-                            .cornerRadius(8)
+                        }
+                        
+                        // Country Selection
+                        VStack(alignment: .leading, spacing: 8) {
+                            Label("Country", systemImage: "globe")
+                                .font(.headline)
+                                .foregroundColor(.primary)
+                            
+                            Button(action: {
+                                isNameFocused = false
+                                showCountrySelection = true
+                            }) {
+                                HStack {
+                                    Text(selectedCountry.flag)
+                                        .font(.title2)
+                                    Text(selectedCountry.localizedName)
+                                        .foregroundColor(.primary)
+                                    Spacer()
+                                    Image(systemName: "chevron.right")
+                                        .foregroundColor(.secondary)
+                                        .font(.caption)
+                                }
+                                .padding()
+                                .background(Color(.systemGray6))
+                                .cornerRadius(8)
+                            }
                         }
                     }
+                    .padding(.horizontal)
+                    
+                    // Spacer to prevent bottom inset button overlap while scrolling
+                    Color.clear
+                        .frame(height: 90)
                 }
-                .padding(.horizontal)
-                
-                Spacer()
-                
-                // Start Button
+            }
+            .safeAreaInset(edge: .bottom) {
                 Button(action: {
                     saveProfile()
                 }) {
@@ -121,10 +131,19 @@ struct OnboardingView: View {
                 }
                 .disabled(childName.isEmpty)
                 .padding(.horizontal)
-                .padding(.bottom, 30)
+                .padding(.bottom, 12)
+                .padding(.top, 8)
+                .background(.ultraThinMaterial)
             }
             .navigationBarHidden(true)
-            .animation(.easeInOut, value: showDatePicker)
+            .onChange(of: birthDate) { _ in
+                // После выбора даты сворачиваем календарь, чтобы было понятно, что делать дальше
+                if showDatePicker {
+                    withAnimation(.easeInOut) {
+                        showDatePicker = false
+                    }
+                }
+            }
         }
         .sheet(isPresented: $showCountrySelection) {
             CountrySelectionSheet(selectedCountry: $selectedCountry)

--- a/Vaccinations2_0/Views/PaywallView.swift
+++ b/Vaccinations2_0/Views/PaywallView.swift
@@ -1,0 +1,230 @@
+//
+//  PaywallView.swift
+//  VaccineCalendar
+//
+
+import SwiftUI
+import StoreKit
+
+struct PaywallView: View {
+    @EnvironmentObject var subscriptionManager: SubscriptionManager
+    @State private var selectedProductID: String = SubscriptionManager.ProductID.yearly
+
+    @State private var promoCode: String = ""
+    @State private var showErrorAlert: Bool = false
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Unlock Premium")
+                            .font(.largeTitle)
+                            .fontWeight(.bold)
+
+                        Text("After registration, choose a plan to continue.")
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(.top, 16)
+
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("Plans")
+                            .font(.headline)
+                            .foregroundColor(.secondary)
+
+                        ForEach(displayProducts, id: \.id) { product in
+                            PlanRow(
+                                title: planTitle(for: product),
+                                subtitle: planSubtitle(for: product),
+                                price: product.displayPrice,
+                                isSelected: selectedProductID == product.id
+                            ) {
+                                selectedProductID = product.id
+                            }
+                        }
+
+                        if subscriptionManager.products.isEmpty && !subscriptionManager.isLoading {
+                            Text("Plans are temporarily unavailable. You can still restore purchases or use a promo code.")
+                                .font(.footnote)
+                                .foregroundColor(.secondary)
+                                .padding(.top, 4)
+                        }
+                    }
+
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("Promo code")
+                            .font(.headline)
+                            .foregroundColor(.secondary)
+
+                        HStack(spacing: 10) {
+                            TextField("Enter promo code", text: $promoCode)
+                                .textInputAutocapitalization(.never)
+                                .autocorrectionDisabled()
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+
+                            Button("Apply") {
+                                subscriptionManager.applyPromoCode(promoCode)
+                                if subscriptionManager.hasPremiumAccess {
+                                    promoCode = ""
+                                } else if subscriptionManager.lastErrorMessage != nil {
+                                    showErrorAlert = true
+                                }
+                            }
+                            .buttonStyle(.bordered)
+                        }
+                    }
+
+                    VStack(spacing: 12) {
+                        Button(action: {
+                            Task { await purchaseSelected() }
+                        }) {
+                            HStack {
+                                Text(primaryButtonTitle)
+                                Spacer()
+                                if subscriptionManager.isLoading {
+                                    ProgressView()
+                                } else {
+                                    Image(systemName: "arrow.right")
+                                }
+                            }
+                            .font(.headline)
+                            .foregroundColor(.white)
+                            .padding()
+                            .background(subscriptionManager.isLoading ? Color.gray : Color.blue)
+                            .cornerRadius(12)
+                        }
+                        .disabled(subscriptionManager.isLoading || selectedProduct == nil)
+
+                        Button(action: {
+                            Task { await subscriptionManager.restorePurchases() }
+                        }) {
+                            Text("Restore purchases")
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(subscriptionManager.isLoading)
+                    }
+                    .padding(.top, 6)
+
+                    Text("Monthly: $5. Yearly: $30. Yearly plan includes a 1-week free trial for new subscribers (configured in App Store Connect).")
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                        .padding(.top, 4)
+                }
+                .padding(.horizontal)
+                .padding(.bottom, 24)
+            }
+            .navigationBarHidden(true)
+            .onAppear {
+                if subscriptionManager.products.isEmpty {
+                    Task { await subscriptionManager.loadProducts() }
+                }
+            }
+            .onChange(of: subscriptionManager.products) { newProducts in
+                if !newProducts.isEmpty, selectedProduct == nil {
+                    selectedProductID = newProducts.first?.id ?? selectedProductID
+                }
+            }
+            .onChange(of: subscriptionManager.lastErrorMessage) { newValue in
+                if newValue != nil {
+                    showErrorAlert = true
+                }
+            }
+            .alert("Error", isPresented: $showErrorAlert) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(subscriptionManager.lastErrorMessage ?? "Unknown error")
+            }
+        }
+    }
+
+    private var displayProducts: [Product] {
+        let dict = Dictionary(uniqueKeysWithValues: subscriptionManager.products.map { ($0.id, $0) })
+        return [SubscriptionManager.ProductID.yearly, SubscriptionManager.ProductID.monthly]
+            .compactMap { dict[$0] }
+    }
+
+    private var selectedProduct: Product? {
+        subscriptionManager.products.first(where: { $0.id == selectedProductID })
+    }
+
+    private var primaryButtonTitle: String {
+        if selectedProductID == SubscriptionManager.ProductID.yearly {
+            return "Start free trial"
+        }
+        return "Continue"
+    }
+
+    private func planTitle(for product: Product) -> String {
+        switch product.id {
+        case SubscriptionManager.ProductID.monthly:
+            return "Monthly"
+        case SubscriptionManager.ProductID.yearly:
+            return "Yearly"
+        default:
+            return product.displayName
+        }
+    }
+
+    private func planSubtitle(for product: Product) -> String {
+        switch product.id {
+        case SubscriptionManager.ProductID.yearly:
+            return "1 week free, then billed yearly"
+        case SubscriptionManager.ProductID.monthly:
+            return "Billed monthly"
+        default:
+            return ""
+        }
+    }
+
+    private func purchaseSelected() async {
+        guard let product = selectedProduct else { return }
+        await subscriptionManager.purchase(product: product)
+    }
+}
+
+private struct PlanRow: View {
+    let title: String
+    let subtitle: String
+    let price: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .foregroundColor(isSelected ? .blue : .secondary)
+                    .font(.title3)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack {
+                        Text(title)
+                            .font(.headline)
+                            .foregroundColor(.primary)
+                        Spacer()
+                        Text(price)
+                            .font(.headline)
+                            .foregroundColor(.primary)
+                    }
+                    if !subtitle.isEmpty {
+                        Text(subtitle)
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+            .padding()
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(isSelected ? Color.blue.opacity(0.1) : Color.gray.opacity(0.05))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(isSelected ? Color.blue : Color.clear, lineWidth: 2)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+


### PR DESCRIPTION
Implements in-app subscriptions via StoreKit2, improves onboarding date picker usability, and reorders the country list to place USA first.

The onboarding date picker, when using `GraphicalDatePickerStyle()`, expanded to push the "Start" button off-screen, making it unclear how to proceed. This is resolved by making the button sticky and collapsing the date picker automatically.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a41f814-2478-4c09-8903-12bb03126529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0a41f814-2478-4c09-8903-12bb03126529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds StoreKit 2 subscription flow with a paywall and entitlement checks, integrates it into app navigation, improves onboarding form usability, and reorders countries to place USA first.
> 
> - **In‑App Purchases**:
>   - **`SubscriptionManager`**: StoreKit 2 integration for loading products, purchasing, restoring, entitlement refresh, transaction updates, and a simple in‑app promo code.
>   - **`PaywallView`**: Plan selection (yearly with free trial, monthly), purchase/restore actions, promo code input, loading/error handling.
> - **App Integration**:
>   - **`VaccineCalendarApp`**: Provides `SubscriptionManager` via `.environmentObject`.
>   - **`ContentView`**: Routes to `PaywallView` when `childProfile` exists without premium; refreshes entitlements on appear.
> - **Onboarding UX**:
>   - **`OnboardingView`**: Switch to scrollable layout with sticky bottom "Start" button (`safeAreaInset`), animated date picker toggle with auto‑collapse on change, improved focus handling, and simplified country selection sheet.
> - **Data**:
>   - **`Country`**: Reordered to place `usa` first (flag/display/localized switch entries updated accordingly).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecf721348acffd1e7070ac426d920154d20aec92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->