### PR TITLE
App description EULA link

### DIFF
--- a/APP_STORE_DESCRIPTION.md
+++ b/APP_STORE_DESCRIPTION.md
@@ -1,0 +1,8 @@
+## App Description (for App Store Connect)
+
+Vaccination schedule tracker for families.
+
+### Terms of Use (EULA)
+
+Apple Standard EULA: https://www.apple.com/legal/internet-services/itunes/dev/stdeula/
+

--- a/VaccinationTracker/README.md
+++ b/VaccinationTracker/README.md
@@ -165,6 +165,10 @@ Users can configure:
 - User has full control over their data
 - Can delete all data at any time through settings
 
+## Terms of Use (EULA)
+
+- Apple Standard EULA: https://www.apple.com/legal/internet-services/itunes/dev/stdeula/
+
 ## Troubleshooting
 
 ### Build Issues

--- a/Vaccinations2_0/Resources/Legal/terms-of-use.md
+++ b/Vaccinations2_0/Resources/Legal/terms-of-use.md
@@ -28,7 +28,11 @@ To the maximum extent permitted by law, the developer is not liable for any indi
 
 ## 6. Apple Standard EULA
 
-If applicable, Apple’s Standard EULA also applies. If there is any conflict, the terms presented in the App purchase flow and the App Store rules prevail.
+If applicable, Apple’s Standard EULA also applies:
+
+- https://www.apple.com/legal/internet-services/itunes/dev/stdeula/
+
+If there is any conflict, the terms presented in the App purchase flow and the App Store rules prevail.
 
 ## 7. Contact
 


### PR DESCRIPTION
Add Apple Standard EULA link to the app description, legal document, and README to comply with App Store requirements.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e52af35-4f5a-4dbb-8046-fb2c8ac9eaea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8e52af35-4f5a-4dbb-8046-fb2c8ac9eaea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

